### PR TITLE
[Day 9] Use better parsing of compressed string

### DIFF
--- a/day_9/src/decompressor.erl
+++ b/day_9/src/decompressor.erl
@@ -1,34 +1,21 @@
 -module(decompressor).
 -export([decompress/1]).
 
-contains_marker([_,_,_]) -> true;
+contains_marker([_,_,_,_]) -> true;
 contains_marker([_]) -> false.
 
-extract_marker(Marker) ->
-    Delimiter = string:chr(Marker, $x),
-    Size = string:substr(Marker, 1, Delimiter-1),
-    Count = string:substr(Marker, 1+Delimiter),
-    {list_to_integer(Size), list_to_integer(Count)}.
-
-expand([Prefix, Marker, Suffix]) -> 
-    {Size, Count} = extract_marker(Marker),
+expand([Prefix, SizeString, CountString, Suffix]) -> 
+    Size = list_to_integer(SizeString),
+    Count = list_to_integer(CountString),
     Repeat = string:substr(Suffix, 1, Size),
     Remainder = string:substr(Suffix, 1+Size),
     Decompressed = lists:flatten(lists:duplicate(Count, Repeat)),
     {Prefix, Decompressed, Remainder}.
 
-split(Compressed) ->
-    StartOfMarker = string:chr(Compressed, $(),
-    EndOfMarker = string:chr(Compressed, $)),
-    case StartOfMarker of
-        0 -> [Compressed];
-        _ -> [ string:substr(Compressed, 1, StartOfMarker-1), string:substr(Compressed, 1+StartOfMarker, EndOfMarker-StartOfMarker-1), string:substr(Compressed, 1+EndOfMarker)]
-    end.
-    
 decompress(Compressed) -> decompress(Compressed, "").
 
 decompress(Compressed, Expanded) -> 
-    Data = split(Compressed),
+    Data = re:split(Compressed, "[(x)]", [{return, list}, {parts, 4}]),
     case contains_marker(Data) of
         false -> Expanded ++ Compressed;
         true -> {Prefix, Decompressed, Suffix} = expand(Data),

--- a/day_9/src/decompressor2.erl
+++ b/day_9/src/decompressor2.erl
@@ -1,35 +1,22 @@
 -module(decompressor2).
 -export([decompress/1]).
 
-contains_marker([_,_,_]) -> true;
+contains_marker([_,_,_,_]) -> true;
 contains_marker([_]) -> false.
 
-extract_marker(Marker) ->
-    Delimiter = string:chr(Marker, $x),
-    Size = string:substr(Marker, 1, Delimiter-1),
-    Count = string:substr(Marker, 1+Delimiter),
-    {list_to_integer(Size), list_to_integer(Count)}.
-
-expand([Prefix, Marker, Suffix]) -> 
-    {Size, Count} = extract_marker(Marker),
+expand([Prefix, SizeString, CountString, Suffix]) -> 
+    Size = list_to_integer(SizeString),
+    Count = list_to_integer(CountString),
     Repeat = string:substr(Suffix, 1, Size),
     ExpandedRepeat = decompress(Repeat),
     Remainder = string:substr(Suffix, 1+Size),
     Decompressed = lists:flatten(lists:duplicate(Count, ExpandedRepeat)),
     {Prefix, Decompressed, Remainder}.
 
-split(Compressed) ->
-    StartOfMarker = string:chr(Compressed, $(),
-    EndOfMarker = string:chr(Compressed, $)),
-    case StartOfMarker of
-        0 -> [Compressed];
-        _ -> [ string:substr(Compressed, 1, StartOfMarker-1), string:substr(Compressed, 1+StartOfMarker, EndOfMarker-StartOfMarker-1), string:substr(Compressed, 1+EndOfMarker)]
-    end.
-    
 decompress(Compressed) -> decompress(Compressed, "").
 
 decompress(Compressed, Expanded) -> 
-    Data = split(Compressed),
+    Data = re:split(Compressed, "[(x)]", [{return, list}, {parts, 4}]),
     case contains_marker(Data) of
         false -> Expanded ++ Compressed;
         true -> {Prefix, Decompressed, Suffix} = expand(Data),

--- a/day_9/src/decompressor3.erl
+++ b/day_9/src/decompressor3.erl
@@ -1,36 +1,22 @@
 -module(decompressor3).
 -export([decompress/1]).
 
-contains_marker([_,_,_]) -> true;
+contains_marker([_,_,_,_]) -> true;
 contains_marker([_]) -> false.
 
-extract_marker(Marker) ->
-    Delimiter = string:chr(Marker, $x),
-    Size = string:substr(Marker, 1, Delimiter-1),
-    Count = string:substr(Marker, 1+Delimiter),
-    {list_to_integer(Size), list_to_integer(Count)}.
-
-expand([Prefix, Marker, Suffix]) -> 
-    {Size, Count} = extract_marker(Marker),
+expand([Prefix, SizeString, CountString, Suffix]) -> 
+    Size = list_to_integer(SizeString),
+    Count = list_to_integer(CountString),
     Repeat = string:substr(Suffix, 1, Size),
     ExpandedRepeatCount = decompress(Repeat),
     Remainder = string:substr(Suffix, 1+Size),
-    %Decompressed = lists:flatten(lists:duplicate(Count, ExpandedRepeat)),
     DecompressedSize = Count * ExpandedRepeatCount,
     {length(Prefix), DecompressedSize, Remainder}.
 
-split(Compressed) ->
-    StartOfMarker = string:chr(Compressed, $(),
-    EndOfMarker = string:chr(Compressed, $)),
-    case StartOfMarker of
-        0 -> [Compressed];
-        _ -> [ string:substr(Compressed, 1, StartOfMarker-1), string:substr(Compressed, 1+StartOfMarker, EndOfMarker-StartOfMarker-1), string:substr(Compressed, 1+EndOfMarker)]
-    end.
-    
 decompress(Compressed) -> decompress(Compressed, 0).
 
 decompress(Compressed, Expanded) -> 
-    Data = split(Compressed),
+    Data = re:split(Compressed, "[(x)]", [{return, list}, {parts, 4}]),
     case contains_marker(Data) of
         false -> Expanded + length(Compressed);
         true -> {Prefix, Decompressed, Suffix} = expand(Data),


### PR DESCRIPTION
Problem:
- There is a lot of custom parsing code that can be replaced by a regex split.

Solution:
- Remove custom parsing code.